### PR TITLE
Add support for external media providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "emoji-mart-vue": "^2.6.4",
     "favico.js": "^0.3.10",
     "fuzzysort": "^1.1.4",
+    "giphy-js-sdk-core": "^1.0.6",
     "highlight.js": "^9.13.1",
     "i18next": "^15.0.7",
     "i18next-browser-languagedetector": "^3.0.1",

--- a/public/config.example.js
+++ b/public/config.example.js
@@ -1,2 +1,3 @@
 window.SystemAPI = `https://system.api.latest.crust.tech`
 window.MessagingAPI = `https://messaging.api.latest.crust.tech`
+window.MediaProviders = [{ type: 'giphy', params: { apiKey: '...' } }]

--- a/src/components/MessageInput/GifPicker.vue
+++ b/src/components/MessageInput/GifPicker.vue
@@ -1,0 +1,50 @@
+<template>
+  <!-- Temporary component. Later this will most likely be moved to a quill plugin -->
+  <div class="picker">
+    <img
+      v-for="gif in gifs"
+      :key="gif.id"
+      :src="gif.previewUrl"
+      class="gif"
+      v-on="$listeners"
+      @click="$emit('pick', gif)" />
+
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    gifs: {
+      type: Array,
+      default: () => [],
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+@import '@/assets/sass/_0.declare.scss';
+.picker {
+  transform: translateY(-100%);
+  position: absolute;
+  width: 100%;
+  background-color: $mainbgcolor;
+  box-shadow: 0 0 3px rgba($black, 0.4);
+  overflow-x: scroll;
+  display: flex;
+  overflow-y: hidden;
+  padding: 5px 0;
+
+  .gif {
+    cursor: pointer;
+    height: 100px;
+    width: 100%;
+    margin-right: 5px;
+    &:last-of-type {
+      margin-right: 0;
+    }
+  }
+}
+
+</style>

--- a/src/components/MessageInput/GifPicker.vue
+++ b/src/components/MessageInput/GifPicker.vue
@@ -24,22 +24,22 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '@/assets/sass/_0.declare.scss';
+@import '@/assets/sass/variables.scss';
 .picker {
   transform: translateY(-100%);
   position: absolute;
   width: 100%;
-  background-color: $mainbgcolor;
+  background-color: $light;
   box-shadow: 0 0 3px rgba($black, 0.4);
   overflow-x: scroll;
-  display: flex;
   overflow-y: hidden;
   padding: 5px 0;
+  white-space: nowrap;
 
   .gif {
+    display: inline-block;
     cursor: pointer;
     height: 100px;
-    width: 100%;
     margin-right: 5px;
     &:last-of-type {
       margin-right: 0;

--- a/src/external/content/giphy.js
+++ b/src/external/content/giphy.js
@@ -1,0 +1,65 @@
+import GphApiClient from 'giphy-js-sdk-core'
+import Provider from './index'
+
+export class Gif {
+  constructor ({ id, previewUrl, url, from, meta = {} }) {
+    this.id = id
+    this.previewUrl = previewUrl
+    this.url = url
+    this.from = from
+    this.meta = meta
+  }
+}
+
+export default class Giphy extends Provider {
+  constructor ({ apiKey }) {
+    super()
+    this.apiKey = apiKey
+    this.connected = false
+  }
+
+  async connect () {
+    return new Promise((resolve, reject) => {
+      if (this.connected) resolve(true)
+
+      this.client = GphApiClient(this.apiKey)
+      this.connected = true
+      resolve(true)
+    })
+  }
+
+  async disconnect () {
+    return new Promise((resolve, reject) => {
+      this.client = undefined
+      this.connected = false
+      resolve(true)
+    })
+  }
+
+  async destroy () {
+    if (this.client) {
+      await this.disconnect()
+    }
+
+    return new Promise((resolve, reject) => {
+      this.client = undefined
+      resolve(true)
+    })
+  }
+
+  async get ({ query: q, limit = 10, offset = 0 }) {
+    return new Promise((resolve, reject) => {
+      this.client[q ? 'search' : 'trending']('gifs', { q, limit, offset }).then(({ data }) => {
+        resolve(
+          data.map(({ id, images: { preview_gif: preview, original } }) => new Gif({
+            id,
+            previewUrl: preview.url,
+            url: original.url,
+            from: this.constructor.name,
+            meta: { height: `${preview.height}px`, width: `${preview.width}px` },
+          }))
+        )
+      }).catch((e) => reject(e))
+    })
+  }
+}

--- a/src/external/content/index.js
+++ b/src/external/content/index.js
@@ -1,0 +1,27 @@
+export default class Provider {
+  constructor () {
+    if (this.constructor === Provider) {
+      throw new TypeError('class.abstract.noConstructor')
+    }
+  }
+
+  async connect () {
+    throw new TypeError('class.abstract.noFunctionOverwrite')
+  }
+
+  async disconnect () {
+    throw new TypeError('class.abstract.noFunctionOverwrite')
+  }
+
+  async destroy () {
+    throw new TypeError('class.abstract.noFunctionOverwrite')
+  }
+
+  async get () {
+    throw new TypeError('class.abstract.noFunctionOverwrite')
+  }
+
+  async put () {
+    throw new TypeError('class.abstract.noFunctionOverwrite')
+  }
+}

--- a/src/plugins/external_content.js
+++ b/src/plugins/external_content.js
@@ -1,0 +1,86 @@
+/**
+ * Plugin allows access to external content providers such as giphy.
+ * To add a new provider, you should create a class and extend the `Provider` (/api/media/index.js)
+ * On plugin registration, specify what providers to use.
+ */
+
+/**
+ * determines what provider to use, if one not specified.
+ * @param {String} provider providers type or key
+ * @param {Object} providers provider array
+ */
+const getProvider = ({ provider, providers }) => {
+  if (!provider && Object.keys(providers).length > 1) {
+    return false
+  } else if (!provider) {
+    provider = Object.keys(providers)[0]
+  }
+
+  if (!provider) {
+    return false
+  }
+  return providers[provider]
+}
+
+export default {
+  install (Vue, { providers = [] }) {
+    let loaded = {}
+
+    // Dynamic provider loading
+    providers.map(({ type, key, params = {} }) => require([`../external/content/${type}.js`], ({ default: ProviderClass }) => {
+      const provider = new ProviderClass(params)
+      loaded[key || type] = provider
+    }))
+
+    Vue.prototype.$externalContent = {
+      providers: loaded,
+
+      async connect ({ provider } = {}) {
+        return new Promise((resolve, reject) => {
+          provider = getProvider({ provider, providers: this.providers })
+          if (!provider) {
+            reject(new Error('provider.notSpecified', Object.keys(this.providers)))
+          }
+
+          return provider.connect().then(resolve, reject)
+        })
+      },
+
+      async disconnect ({ provider } = {}) {
+        return new Promise((resolve, reject) => {
+          provider = getProvider({ provider, providers: this.providers })
+          if (!provider) {
+            reject(new Error('provider.notSpecified', Object.keys(this.providers)))
+          }
+
+          return provider.disconnect().then(resolve, reject)
+        })
+      },
+
+      async destroy ({ provider } = {}) {
+        return new Promise((resolve, reject) => {
+          provider = getProvider({ provider, providers: this.providers })
+          if (!provider) {
+            reject(new Error('provider.notSpecified', Object.keys(this.providers)))
+          }
+
+          return provider.destroy().then(resolve, reject)
+        })
+      },
+
+      async get ({ provider, params = {} } = {}) {
+        return new Promise((resolve, reject) => {
+          provider = getProvider({ provider, providers: this.providers })
+          if (!provider) {
+            reject(new Error('provider.notSpecified', Object.keys(this.providers)))
+          }
+
+          provider.connect().then((connected) => {
+            if (!connected) reject(new Error('provider.connectFailed'))
+            return provider.get(params).then(resolve, reject)
+          }).catch((e) => reject(e))
+        })
+      },
+    }
+  },
+}

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -7,6 +7,7 @@ import messaging from 'corteza-webapp-common/src/plugins/messaging'
 import commands from '@/plugins/commands'
 import triggers from '@/plugins/triggers'
 import auth from 'corteza-webapp-common/src/plugins/auth'
+import externalContent from './external_content'
 
 const eventbus = new Vue()
 
@@ -22,3 +23,4 @@ Vue.use(triggers, {
   channelByID: store.getters['channels/findByID'],
   channelList: store.getters['channels/listOnDemand'],
 })
+Vue.use(externalContent, { providers: window.MediaProviders })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1423,6 +1423,11 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
+asap@~2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
+
 asn1.js@^4.0.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
@@ -3113,6 +3118,13 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
+  dependencies:
+    iconv-lite "~0.4.13"
+
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
@@ -3175,6 +3187,11 @@ es-to-primitive@^1.2.0:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+es6-promise@^4.1.0:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
+  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -3947,6 +3964,16 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+giphy-js-sdk-core@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/giphy-js-sdk-core/-/giphy-js-sdk-core-1.0.6.tgz#3877988a71ee27e6d250b00713703917fca48510"
+  integrity sha512-WaOm2ZEMSyPzlM+XbiVSDPZiSNfNfCItIeLh9QNglqiSl5fqewjTl7TY9wJT41Q/ORyOekV5rJDe4EIkjLDLFw==
+  dependencies:
+    es6-promise "^4.1.0"
+    isomorphic-fetch "^2.2.1"
+    lodash "^4.17.4"
+    promise "^7.1.1"
+
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
@@ -4358,7 +4385,7 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.4:
+iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -4771,7 +4798,7 @@ is-resolvable@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
   integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
 
-is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -4838,6 +4865,14 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+
+isomorphic-fetch@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -5757,6 +5792,14 @@ node-ensure@^0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/node-ensure/-/node-ensure-0.0.0.tgz#ecae764150de99861ec5c810fd5d096b183932a7"
   integrity sha1-7K52QVDemYYexcgQ/V0Jaxg5Mqc=
+
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-forge@0.7.5:
   version "0.7.5"
@@ -6851,6 +6894,13 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
+promise@^7.1.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
+  dependencies:
+    asap "~2.0.3"
 
 proxy-addr@~2.0.4:
   version "2.0.4"
@@ -8850,6 +8900,11 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@>=0.10.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Support for providers such as giphy, ...

The plugin is generalized to support any custom providers.
To add a new provider, create a new class and extend the base Provider class.
To use a provider, specify it when registering the plugin.

Ref: https://github.com/crusttech/webapp-messaging/issues/52