### PR TITLE
Reflect channel creating permissions on UI. + simple channel creation error notifications

### DIFF
--- a/src/components/Lightboxed/QuickSearch.vue
+++ b/src/components/Lightboxed/QuickSearch.vue
@@ -13,7 +13,7 @@
               <li v-for="i in (query ? filtered : preferred).slice(0, 10)"
                   @click="onClose"
                   :key="i.ID">
-                <component :is="i.cmp" :ID="i.ID" :canCreate="canCreate" ></component>
+                <component :is="i.cmp" :ID="i.ID" :canCreateGroupChannel="canCreateGroupChannel" ></component>
               </li>
           </ol>
       </main>
@@ -59,6 +59,7 @@ export default {
     ...mapGetters({
       channels: 'channels/list',
       users: 'users/list',
+      canCreateGroupChannel: 'session/canCreateGroupChannel',
     }),
 
     filtered () {
@@ -81,15 +82,6 @@ export default {
         ...this.channels.filter(c => !c.isDirectMessage()).map(cmp('channel')),
       ]
     },
-  },
-
-  created () {
-    this.$MessagingAPI.permissionsEffective().then(e => {
-      const canCreate = e.find(p => p.operation === 'channel.private.create')
-      if (canCreate) {
-        this.canCreate = canCreate.allow
-      }
-    })
   },
 
   methods: {

--- a/src/components/Lightboxed/QuickSearch.vue
+++ b/src/components/Lightboxed/QuickSearch.vue
@@ -13,7 +13,7 @@
               <li v-for="i in (query ? filtered : preferred).slice(0, 10)"
                   @click="onClose"
                   :key="i.ID">
-                <component :is="i.cmp" :ID="i.ID" ></component>
+                <component :is="i.cmp" :ID="i.ID" :canCreate="canCreate" ></component>
               </li>
           </ol>
       </main>
@@ -51,6 +51,7 @@ export default {
   data () {
     return {
       query: '',
+      canCreate: false,
     }
   },
 
@@ -80,6 +81,15 @@ export default {
         ...this.channels.filter(c => !c.isDirectMessage()).map(cmp('channel')),
       ]
     },
+  },
+
+  created () {
+    this.$MessagingAPI.permissionsEffective().then(e => {
+      const canCreate = e.find(p => p.operation === 'channel.private.create')
+      if (canCreate) {
+        this.canCreate = canCreate.allow
+      }
+    })
   },
 
   methods: {

--- a/src/components/Panel/Channels/Group.vue
+++ b/src/components/Panel/Channels/Group.vue
@@ -1,7 +1,7 @@
 <template>
   <section>
     <div>
-      <router-link v-if="link" :to="link" @click.native="$emit('close')">
+      <router-link v-if="link && canCreate" :to="link" @click.native="$emit('close')">
         <i class="icon icon-left icon-plus btn"></i>
       </router-link>
       <a @click="expanded=!expanded">
@@ -45,6 +45,12 @@ export default {
     current: {
       type: Object,
       required: false,
+    },
+
+    canCreate: {
+      type: Boolean,
+      required: false,
+      default: false,
     },
   },
 

--- a/src/components/Panel/Channels/index.vue
+++ b/src/components/Panel/Channels/index.vue
@@ -31,7 +31,7 @@
       <group v-on="$listeners"
              :link="{name: 'new-channel', params: { type: 'public' } }"
              :list="publicChannels"
-             :canCreate="effective['channel.public.create']"
+             :canCreate="canCreatePublicChannel"
              :current="channel"
              class="channel-group">{{ $t('panel.channel.public') }}</group>
 
@@ -42,13 +42,13 @@
       <group v-on="$listeners"
              :link="{name: 'new-channel', params: { type: 'private' } }"
              :list="privateChannels"
-             :canCreate="effective['channel.private.create']"
+             :canCreate="canCreatePrivateChannel"
              :current="channel">{{ $t('panel.channel.private') }}</group>
 
       <group v-on="$listeners"
              :link="{name: 'new-channel', params: { type: 'group' } }"
              :list="groupChannels"
-             :canCreate="effective['channel.group.create']"
+             :canCreate="canCreateGroupChannel"
              :current="channel">{{ $t('panel.channel.group') }}</group>
     </div>
 
@@ -84,7 +84,6 @@ export default {
       groupUnfold: true,
       privateUnfold: true,
       publicUnfold: true,
-      effective: {},
     }
   },
 
@@ -94,6 +93,9 @@ export default {
       findUserByID: 'users/findByID',
       channels: 'channels/list',
       unreadFinder: 'unread/find',
+      canCreateGroupChannel: 'session/canCreateGroupChannel',
+      canCreatePrivateChannel: 'session/canCreatePrivateChannel',
+      canCreatePublicChannel: 'session/canCreatePublicChannel',
     }),
 
     // Returns filtered list of channels
@@ -142,16 +144,6 @@ export default {
     groupChannels () {
       return this.channelSlicer(this.unpinnedChannels.filter(c => c.isGroup()), this.sortByOnlineStatus)
     },
-  },
-
-  created () {
-    this.$MessagingAPI.permissionsEffective().then(e => {
-      e.forEach(p => {
-        if (p.operation.indexOf('create') > -1) {
-          this.effective[p.operation] = p.allow
-        }
-      })
-    })
   },
 
   methods: {

--- a/src/components/Panel/Channels/index.vue
+++ b/src/components/Panel/Channels/index.vue
@@ -31,6 +31,7 @@
       <group v-on="$listeners"
              :link="{name: 'new-channel', params: { type: 'public' } }"
              :list="publicChannels"
+             :canCreate="effective['channel.public.create']"
              :current="channel"
              class="channel-group">{{ $t('panel.channel.public') }}</group>
 
@@ -41,11 +42,13 @@
       <group v-on="$listeners"
              :link="{name: 'new-channel', params: { type: 'private' } }"
              :list="privateChannels"
+             :canCreate="effective['channel.private.create']"
              :current="channel">{{ $t('panel.channel.private') }}</group>
 
       <group v-on="$listeners"
              :link="{name: 'new-channel', params: { type: 'group' } }"
              :list="groupChannels"
+             :canCreate="effective['channel.group.create']"
              :current="channel">{{ $t('panel.channel.group') }}</group>
     </div>
 
@@ -81,6 +84,7 @@ export default {
       groupUnfold: true,
       privateUnfold: true,
       publicUnfold: true,
+      effective: {},
     }
   },
 
@@ -138,6 +142,16 @@ export default {
     groupChannels () {
       return this.channelSlicer(this.unpinnedChannels.filter(c => c.isGroup()), this.sortByOnlineStatus)
     },
+  },
+
+  created () {
+    this.$MessagingAPI.permissionsEffective().then(e => {
+      e.forEach(p => {
+        if (p.operation.indexOf('create') > -1) {
+          this.effective[p.operation] = p.allow
+        }
+      })
+    })
   },
 
   methods: {

--- a/src/components/User/Link.vue
+++ b/src/components/User/Link.vue
@@ -18,7 +18,7 @@ export default {
       type: Boolean,
       default: true,
     },
-    canCreate: {
+    canCreateGroupChannel: {
       type: Boolean,
       default: false,
     },
@@ -35,9 +35,10 @@ export default {
       if (ch) {
         return { name: 'channel', params: { channelID: ch.channelID } }
       } else {
-        if (this.canCreate) {
+        if (this.canCreateGroupChannel) {
           return { name: 'profile', params: { userID: this.ID } }
         } else {
+          // Cant click on a user if no previous conversation and no permission
           return ''
         }
       }

--- a/src/components/User/Link.vue
+++ b/src/components/User/Link.vue
@@ -18,6 +18,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    canCreate: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   computed: {
@@ -31,7 +35,11 @@ export default {
       if (ch) {
         return { name: 'channel', params: { channelID: ch.channelID } }
       } else {
-        return { name: 'profile', params: { userID: this.ID } }
+        if (this.canCreate) {
+          return { name: 'profile', params: { userID: this.ID } }
+        } else {
+          return ''
+        }
       }
     },
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -10,6 +10,7 @@ import history from './history'
 import unread from './unread'
 import settings from './settings'
 import suggestions from './suggestions'
+import session from './session'
 
 Vue.use(Vuex)
 
@@ -22,6 +23,7 @@ const store = new Vuex.Store({
     settings: settings(MessagingAPI),
     suggestions: suggestions(MessagingAPI),
     unread: unread(MessagingAPI),
+    session: session(MessagingAPI),
   },
 })
 

--- a/src/store/session.js
+++ b/src/store/session.js
@@ -1,0 +1,64 @@
+
+const types = {
+  pending: 'pending',
+  completed: 'completed',
+  updatePermissions: 'updatePermissions',
+}
+
+const findPermission = (state, operation) => {
+  return (state.permissions.find(s => s.operation === operation) || {}).allow
+}
+
+export default function (Messaging) {
+  return {
+    namespaced: true,
+    state: {
+      permissions: [],
+      pending: false,
+    },
+    getters: {
+      pending: (state) => state.pending,
+      canAccess: (state) => (findPermission(state, 'access')),
+      canGrant: (state) => (findPermission(state, 'grant')),
+      canCreateGroupChannel: (state) => (findPermission(state, 'channel.group.create')),
+      canCreatePublicChannel: (state) => (findPermission(state, 'channel.public.create')),
+      canCreatePrivateChannel: (state) => (findPermission(state, 'channel.private.create')),
+    },
+    actions: {
+      async load ({ commit }) {
+        commit(types.pending)
+        Messaging.permissionsEffective().then((permissions) => {
+          commit(types.updatePermissions, permissions)
+          commit(types.completed)
+        })
+      },
+    },
+    mutations: {
+      [types.pending] (state) {
+        state.pending = true
+      },
+
+      [types.completed] (state) {
+        state.pending = false
+      },
+
+      [types.updatePermissions] (state, permissions) {
+        if (state.permissions.length === 0) {
+          state.permissions = permissions
+        } else {
+          permissions.forEach(per => {
+            // Replaces given cmd due to an update
+            const n = state.permissions.findIndex(p => p.operation === per.operation)
+
+            // Doesn't yet exist -- add it
+            if (n < 0) {
+              state.permissions.push(per)
+            } else {
+              state.permissions.splice(n, 1, per)
+            }
+          })
+        }
+      },
+    },
+  }
+}

--- a/src/views/ChannelEditor.vue
+++ b/src/views/ChannelEditor.vue
@@ -11,8 +11,9 @@
       </header>
       <main class="container">
         <form class="editor big-form" @submit.prevent="onSubmit" v-if="!channel.channelID || channel.type !== 'group'">
-          <div v-if="error" class="error">
-            {{error}}
+          <div v-if="error" class="notification error no-margin">
+              <p>{{ $t(error) }}</p>
+              <span @click="error=null" class="close"></span>
           </div>
           <div v-if="channel.type !== 'group'" class="input-wrap">
             <label class="label-block">{{ $t('channel.editor.channelNameLabel') }} *</label>
@@ -295,10 +296,6 @@ export default {
   .title {
     padding-top: 15px;
   }
-}
-
-div.error {
-  color: $danger;
 }
 
 form, main > section {

--- a/src/views/ChannelEditor.vue
+++ b/src/views/ChannelEditor.vue
@@ -198,7 +198,7 @@ export default {
     },
 
     'type' (newType) {
-      if (!this.channel.channelID) this.channel.type = newType
+      if (!this.channel.channelID) this.load()
     },
   },
 

--- a/src/views/Messenger.vue
+++ b/src/views/Messenger.vue
@@ -175,6 +175,7 @@ export default {
       loadUserStatuses: 'users/loadStatuses',
       loadCommands: 'suggestions/loadCommands',
       updateChannelUnreads: 'unread/fromChannel',
+      loadSession: 'session/load',
     }),
 
     init () {
@@ -184,6 +185,7 @@ export default {
 
       this.loadUsers()
       this.loadCommands()
+      this.loadSession()
 
       this.windowResizeHandler()
       window.addEventListener('resize', this.windowResizeHandler)


### PR DESCRIPTION
Prevented creating public/group/private channels based on effectivePermissions. 
If private channel creation is disabled, user cant click to create new private conversations. 

Forced channel creation form reload on channel type switch. 

Error when creating channel: 
![Screenshot from 2019-07-05 12-53-38](https://user-images.githubusercontent.com/15791641/60718075-000cf900-9f24-11e9-97e3-44f4f1125138.png)