### PR TITLE
Suggestion tweaks

### DIFF
--- a/src/components/MessageInput/TextInput.vue
+++ b/src/components/MessageInput/TextInput.vue
@@ -91,10 +91,10 @@ export default {
               if (item.type === 'User') {
                 return `
                   <span class="user group ${item.online ? 'full-moon' : 'new-moon'} ${item.member ? 'member' : ''}">
-                    <span class="channel-name"><span class="label">${item.value}</span></span>
+                    <span class="channel-name"><span class="label">${item.value}<br/><small class="email">${item.user.email}</small></span></span>
                   </span>`
               } else {
-                return `<span class="channel ${item.opts.type}"><span class="channel-name ">${item.value}</span></span>`
+                return `<span class="channel ${item.channel.type}"><span class="channel-name ">${item.value}</span></span>`
               }
             },
             source: function (searchTerm, renderList, mentionChar) {
@@ -108,9 +108,9 @@ export default {
 
                 // In private & group channels, initally show only members
                 if (searchTerm.length === 0 && filterIn.find((e) => e === type)) {
-                  values = values.filter(a => members.find(m => m === a.id))
+                  values = values.filter(a => members.find(m => m === a.user.userID))
                 } else {
-                  values = values.map(v => ({ ...v, member: members.find(m => m === v.id) }))
+                  values = values.map(v => ({ ...v, member: members.find(m => m === v.user.userID) }))
                 }
 
                 // Fuzzy sort
@@ -121,7 +121,7 @@ export default {
                 // Extra sort by presence & membership
                 values = [ ...values ].sort((a, b) => {
                   if (a.online && !b.online && a.id !== meID) return -1
-                  if (members.find(m => m === a.id) && !members.find(m => m === b.id)) return -1
+                  if (members.find(m => m === a.user.userID) && !members.find(m => m === b.user.userID)) return -1
 
                   return 0
                 })
@@ -130,10 +130,10 @@ export default {
 
                 // Show named, not ignored, joined channels
                 if (searchTerm.length === 0) {
-                  values = values.filter(a => a.name && !ignoreFlags.find(e => e === a.opts.membershipFlag) && a.members.find((e) => e === meID))
+                  values = values.filter(a => a.channel.name && !ignoreFlags.find(e => e === a.channel.membershipFlag) && a.channel.members.find((e) => e === meID))
                 } else {
                   values = fuzzysort.go(searchTerm, values, fzsOpts)
-                    .filter(r => !ignoreFlags.find(e => e === r.obj.opts.membershipFlag) || -r.score < r.target.length * 0.65)
+                    .filter(r => !ignoreFlags.find(e => e === r.obj.channel.membershipFlag) || -r.score < r.target.length * 0.65)
                     .map(r => r.obj)
                 }
               }
@@ -322,6 +322,11 @@ export default {
     user-select: text;
   }
 
+  .ql-mention-list-item{
+    font-size: 14px;
+    line-height: inherit;
+  }
+
   @media (max-width: $wideminwidth - 1px)
   {
     .ql-editor
@@ -339,8 +344,10 @@ export default {
   {
     .ql-mention-list-item{
       font-size: 14px;
-      height: 30px;
-      line-height: 30px;
+
+      .email {
+        margin-left: 18px;
+      }
 
       &[data-denotation-char="@"] .label {
         color: $secondary;

--- a/src/components/MessageInput/TextInput.vue
+++ b/src/components/MessageInput/TextInput.vue
@@ -11,6 +11,7 @@ import Quill from 'quill'
 import 'quill/dist/quill.core.css'
 import 'quill/dist/quill.bubble.css'
 import 'quill-mention'
+import { toNFD } from 'corteza-webapp-messaging/src/lib/normalizers'
 const fuzzysort = require('fuzzysort')
 
 const suggestionLimit = 10
@@ -97,6 +98,7 @@ export default {
               }
             },
             source: function (searchTerm, renderList, mentionChar) {
+              searchTerm = toNFD(searchTerm)
               let values
 
               const { userID: meID } = vm.user

--- a/src/components/MessageInput/index.vue
+++ b/src/components/MessageInput/index.vue
@@ -134,8 +134,13 @@ export default {
 
     channelSuggestions () {
       return this.channels.map(c => {
-        const value = c.name || c.channelID || ''
-        return { type: 'Channel', id: c.channelID, value, key: c.fuzzyKey(), members: c.members, name: c.name, opts: { membershipFlag: c.membershipFlag, type: c.type } }
+        return {
+          type: 'Channel',
+          id: c.channelID,
+          channel: c,
+          value: c.suggestionLabel(),
+          key: c.fuzzyKey(),
+        }
       })
     },
 
@@ -145,8 +150,14 @@ export default {
 
     userSuggestions () {
       return this.users.map(u => {
-        const value = u.name || u.userID || ''
-        return { type: 'User', id: u.userID, value, key: u.fuzzyKey(), online: this.onlineStatuses.has(u.userID), name: u.name }
+        return {
+          type: 'User',
+          id: u.userID,
+          user: u,
+          value: u.suggestionLabel(),
+          key: u.fuzzyKey(),
+          online: this.onlineStatuses.has(u.userID),
+        }
       })
     },
 

--- a/src/lib/normalizers.js
+++ b/src/lib/normalizers.js
@@ -1,0 +1,2 @@
+// https://stackoverflow.com/questions/990904/remove-accents-diacritics-in-a-string-in-javascript/37511463#37511463
+export const toNFD = (s) => s.normalize('NFD').replace(/[\u0300-\u036f]/g, '')

--- a/src/types.js
+++ b/src/types.js
@@ -1,3 +1,4 @@
+import { toNFD } from 'corteza-webapp-messaging/src/lib/normalizers'
 const fuzzysort = require('fuzzysort')
 const UINT64_ZEROPAD = '00000000000000000000'
 
@@ -112,7 +113,7 @@ export class User {
   }
 
   fuzzyKey () {
-    return fuzzysort.prepare(this.name || this.userID || '')
+    return fuzzysort.prepare(toNFD(this.name) || this.userID || '')
   }
 
   Match (q) {

--- a/src/types.js
+++ b/src/types.js
@@ -113,7 +113,11 @@ export class User {
   }
 
   fuzzyKey () {
-    return fuzzysort.prepare(toNFD(this.name) || this.userID || '')
+    return fuzzysort.prepare(toNFD(this.suggestionLabel()))
+  }
+
+  suggestionLabel () {
+    return this.handle || this.name || (this.email || '').split('@')[0] || this.userID || ''
   }
 
   Match (q) {

--- a/src/types/channel.js
+++ b/src/types/channel.js
@@ -40,7 +40,11 @@ export class Channel {
   }
 
   fuzzyKey () {
-    return fuzzysort.prepare(toNFD(this.name) || this.channelID || '')
+    return fuzzysort.prepare(toNFD(this.suggestionLabel()))
+  }
+
+  suggestionLabel () {
+    return this.name || this.channelID || ''
   }
 
   isMember (userID) {

--- a/src/types/channel.js
+++ b/src/types/channel.js
@@ -1,3 +1,4 @@
+import { toNFD } from 'corteza-webapp-messaging/src/lib/normalizers'
 const fuzzysort = require('fuzzysort')
 
 export class Channel {
@@ -39,7 +40,7 @@ export class Channel {
   }
 
   fuzzyKey () {
-    return fuzzysort.prepare(this.name || this.channelID || '')
+    return fuzzysort.prepare(toNFD(this.name) || this.channelID || '')
   }
 
   isMember (userID) {


### PR DESCRIPTION
Tweak suggestion display:
* omit diacritical marks so special characters like `ž` can be matched with `z`,
* use the first part of the email (the part before @) for users with no name/handle.