### PR TITLE
Go to message in search

### DIFF
--- a/src/components/Chat/Footer/index.vue
+++ b/src/components/Chat/Footer/index.vue
@@ -93,6 +93,14 @@
         >
           {{ $t('message.markAsRead') }}
         </button>
+
+        <button
+          v-if="hasRecent"
+          class="btn float-right"
+          @click.prevent="$emit('showRecent')"
+        >
+          {{ $t('message.showRecent') }}
+        </button>
       </div>
     </div>
   </div>
@@ -126,6 +134,12 @@ export default {
     },
 
     hasUnread: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+
+    hasRecent: {
       type: Boolean,
       required: false,
       default: false,

--- a/src/components/Messages/Message/index.vue
+++ b/src/components/Messages/Message/index.vue
@@ -13,6 +13,7 @@
       'edited' : message.updatedAt,
       'pinned' : highlightPinned && message.isPinned,
       'bookmarked' : highlightBookmarked && message.isBookmarked,
+      'highlighted': highlightMessage,
       'last-read': isLastRead && !isLast,
       'unread': isUnread,
       'type-channel-event': message.type === 'channelEvent',
@@ -205,6 +206,7 @@ export default {
     // Controling bookmarked and pinned messages highlighting
     highlightBookmarked: { type: Boolean, default: true },
     highlightPinned: { type: Boolean, default: true },
+    highlightMessage: { type: Boolean, default: false },
   },
 
   data () {
@@ -384,6 +386,10 @@ em{
         }
       }
     }
+  }
+
+  &.highlighted {
+    background-color: rgba($warning, 0.3);
   }
 
   &.unread {

--- a/src/components/Messages/index.vue
+++ b/src/components/Messages/index.vue
@@ -11,6 +11,7 @@
       :key="msg.messageID"
       v-bind="$props"
       :message="msg"
+      :highlight-message="highlightMessageID === msg.messageID"
       :consecutive="consecutive && isConsecutive(messages, index)"
       :is-unread="!!lastReadMessageID && lastReadMessageID < msg.messageID"
       :is-last-read="lastReadMessageID === msg.messageID"
@@ -90,6 +91,11 @@ export default {
 
     // This will help us mark new messages
     lastReadMessageID: {
+      type: String,
+      default: undefined,
+    },
+
+    highlightMessageID: {
       type: String,
       default: undefined,
     },

--- a/src/i18n/en/messaging.js
+++ b/src/i18n/en/messaging.js
@@ -111,6 +111,7 @@ export default {
     edited: 'edited',
     typing: 'typing',
     markAsRead: 'Mark as Read',
+    showRecent: 'Show recent messages',
     unread: 'Unread messages',
     markAllAsRead: 'Mark all as read',
     noUnread: 'No unread messages',

--- a/src/mixins/messages.js
+++ b/src/mixins/messages.js
@@ -107,6 +107,10 @@ export default {
      * @returns {Promise<Array<Message>>}
      */
     async onNewMessages (messages, noCheck = false, overwriteState = false) {
+      if (this.hideNewMessages) {
+        return []
+      }
+
       if (!Array.isArray(messages)) {
         messages = [messages]
       }

--- a/src/views/Messenger.vue
+++ b/src/views/Messenger.vue
@@ -267,7 +267,8 @@ export default {
       this.searchQuery = null
 
       // go to channel
-      this.$router.push({ name: 'channel', params: { channelID: message.channelID, messageID: message.messageID } })
+      this.$router.push({ name: 'channel', params: { channelID: message.channelID } })
+      this.$bus.$emit('Messenger/switchRightSidePanel', { type: 'thread', e: { message } })
     },
 
     onEmojiSelect (emoji) {

--- a/src/views/Messenger.vue
+++ b/src/views/Messenger.vue
@@ -268,6 +268,12 @@ export default {
 
       // go to channel
       this.$router.push({ name: 'channel', params: { channelID: message.channelID, messageID: message.messageID } })
+
+      if (message.replies) {
+        this.$bus.$emit('Messenger/switchRightSidePanel', { type: 'thread', e: { message } })
+      } else {
+        this.$bus.$emit('Messenger/switchRightSidePanel', {})
+      }
     },
 
     onEmojiSelect (emoji) {

--- a/src/views/Messenger.vue
+++ b/src/views/Messenger.vue
@@ -267,8 +267,7 @@ export default {
       this.searchQuery = null
 
       // go to channel
-      this.$router.push({ name: 'channel', params: { channelID: message.channelID } })
-      this.$bus.$emit('Messenger/switchRightSidePanel', { type: 'thread', e: { message } })
+      this.$router.push({ name: 'channel', params: { channelID: message.channelID, messageID: message.messageID } })
     },
 
     onEmojiSelect (emoji) {

--- a/src/views/routes.js
+++ b/src/views/routes.js
@@ -17,7 +17,7 @@ export default [
     component: view('Messenger'),
     children: [
       { path: 'channel/new/:type', name: 'new-channel', component: view('ChannelEditor'), props: true },
-      { path: 'channel/:channelID', name: 'channel', component: view('Channel'), props: true },
+      { path: 'channel/:channelID/:messageID?', name: 'channel', component: view('Channel'), props: true },
       { path: 'channel/:channelID/editor', name: 'edit-channel', component: view('ChannelEditor'), props: true },
 
       { path: 'user/:userID', name: 'profile', component: view('Profile'), props: true },


### PR DESCRIPTION
Ref: #35

After clicking the goToMessage button in searchResults, opens the channel with the message context.
Show 10 messages before and after the specific message.
If the message has replies, also open the thread.

Waiting for afterMessageID parameter in searchMessages endpoint.